### PR TITLE
Update URL and description for Herbie CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ A fast simple, blog and framework
 
 **Website:** https://hexo.io/
 
-## Herbie
+## Herbie CMS
 
-Herbie is a simple, fast and highly customizable flat-file Content Management System powered by PHP, Twig, Markdown, Textile, reStructuredText and other human-readable text files. Create small but fully functional websites or blogs in no time and with little effort.
+Herbie CMS is a simple, fast and highly customizable flat-file Content Management System powered by PHP, Twig, Markdown, Textile, reStructuredText and other human-readable text files. Create small but fully functional websites or blogs in no time and with little effort.
 
 **Technology:** PHP
 

--- a/README.md
+++ b/README.md
@@ -261,17 +261,17 @@ A fast simple, blog and framework
 
 ## Herbie
 
-Herbie is a simple, blog-aware, static site generator. Composer support - simple installation - no database - just text files.
+Herbie is a simple, fast and highly customizable flat-file Content Management System powered by PHP, Twig, Markdown, Textile, reStructuredText and other human-readable text files. Create small but fully functional websites or blogs in no time and with little effort.
 
 **Technology:** PHP
 
 **Templating:** Twig
 
-**Formatting:** Markdown
+**Formatting:** Markdown, Textile, reStructuredText
 
 **Open source:** [yes](https://github.com/getherbie/herbie)
 
-**Website:** https://getherbie.org/
+**Website:** https://herbie.tebe.ch/
 
 ## HTMLy
 


### PR DESCRIPTION
The URL of Herbie CMS has changed to <https://herbie.tebe.ch>.

👍 Thanks for merging!